### PR TITLE
Support additional devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Homebridge platform plugin for FRITZ!Box.
 This plugin exposes:
 
   - Wlan guest access switch
-  - Fritz!DECT outlets
+  - Fritz!DECT outlets (100, 200, 210)
+  - Fritz!Powerline outlets (510, 540)
   - Comet!DECT thermostats
 
 

--- a/index.js
+++ b/index.js
@@ -22,9 +22,6 @@ module.exports = function(homebridge) {
     homebridge.registerPlatform("homebridge-fritz", "Fritz!Box", FritzPlatform);
 };
 
-// inherit before assigning prototypes
-inherits(FritzOutletAccessory, FritzAccessory);
-inherits(FritzThermostatAccessory, FritzAccessory);
 
 /**
  * FritzPlatform
@@ -273,6 +270,8 @@ FritzAccessory.prototype.getServices = function() {
  * FritzOutletAccessory
  */
 
+inherits(FritzOutletAccessory, FritzAccessory);
+
 function FritzOutletAccessory(platform, ain) {
     FritzAccessory.apply(this, arguments);
 
@@ -392,6 +391,8 @@ FritzOutletAccessory.prototype.update = function() {
 /**
  * FritzThermostatAccessory
  */
+
+inherits(FritzThermostatAccessory, FritzAccessory);
 
 function FritzThermostatAccessory(platform, ain) {
     FritzAccessory.apply(this, arguments);
@@ -518,6 +519,8 @@ FritzThermostatAccessory.prototype.update = function() {
 /**
  * FritzTemperatureSensorAccessory
  */
+
+inherits(FritzTemperatureSensorAccessory, FritzAccessory);
 
 function FritzTemperatureSensorAccessory(platform, ain) {
     FritzAccessory.apply(this, arguments);

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = function(homebridge) {
 inherits(FritzOutletAccessory, FritzAccessory);
 inherits(FritzThermostatAccessory, FritzAccessory);
 
+
 /**
  * FritzPlatform
  */
@@ -82,7 +83,7 @@ FritzPlatform.prototype = {
 
         this.fritz("getDeviceList").then(function(devices) {
             // cache list of devices in options for reuse by non-API functions
-            self.options.deviceList = devices;
+            self.deviceList = devices;
 
             // outlets
             self.fritz("getSwitchList").then(function(ains) {
@@ -122,7 +123,7 @@ FritzPlatform.prototype = {
     },
 
     getDevice: function(ain) {
-        var device = this.options.deviceList.find(function(device) {
+        var device = this.deviceList.find(function(device) {
             return device.identifier.replace(/\s/g, '') == ain;
         });
         return device || {}; // safeguard

--- a/index.js
+++ b/index.js
@@ -232,12 +232,23 @@ function FritzAccessory(platform, ain) {
 
     this.services = {
         AccessoryInformation: new Service.AccessoryInformation()
-            .setCharacteristic(Characteristic.Manufacturer, this.device.manufacturer)
-            .setCharacteristic(Characteristic.Model, this.device.productname)
             .setCharacteristic(Characteristic.SerialNumber, this.ain)
-            .setCharacteristic(Characteristic.FirmwareRevision, this.device.fwversion)
     };
-};
+
+    // these characteristics will not be present for e.g. device groups
+    if (this.device.manufacturer) {
+        this.services.AccessoryInformation
+            .setCharacteristic(Characteristic.Manufacturer, this.device.manufacturer);
+    }
+    if (this.device.productname) {
+        this.services.AccessoryInformation
+            .setCharacteristic(Characteristic.Model, this.device.productname);
+    }
+    if (this.device.fwversion) {
+        this.services.AccessoryInformation
+            .setCharacteristic(Characteristic.FirmwareRevision, this.device.fwversion);
+    }
+}
 
 FritzAccessory.prototype.getServices = function() {
     return Object.keys(this.services).map(function(key) {
@@ -251,7 +262,7 @@ FritzAccessory.prototype.getServices = function() {
  */
 
 function FritzOutletAccessory(platform, ain) {
-    FritzAccessory.apply(this, arguments)
+    FritzAccessory.apply(this, arguments);
 
     extend(this.services, {
         Outlet: new Service.Outlet(this.name)
@@ -284,7 +295,7 @@ function FritzOutletAccessory(platform, ain) {
         this.services.TemperatureSensor.getCharacteristic(Characteristic.CurrentTemperature)
             .on('get', this.getCurrentTemperature.bind(this))
         ;
-    };
+    }
 
     setInterval(this.update.bind(this), this.platform.interval);
 }
@@ -371,7 +382,7 @@ FritzOutletAccessory.prototype.update = function() {
  */
 
 function FritzThermostatAccessory(platform, ain) {
-    FritzAccessory.apply(this, arguments)
+    FritzAccessory.apply(this, arguments);
 
     extend(this.services, {
         Thermostat: new Service.Thermostat(this.name),
@@ -475,6 +486,7 @@ FritzThermostatAccessory.prototype.getChargingState = function(callback) {
 
 FritzThermostatAccessory.prototype.getStatusLowBattery = function(callback) {
     this.platform.fritz('getBatteryCharge', this.ain).then(function(battery) {
+        /* jshint laxbreak:true */
         callback(null, battery < 20 
             ? Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW
             : Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "extend": "^3.0.0",
-    "smartfritz-promise": "^0.6.1",
+    "fritzapi": "^0.8.0",
     "valid-url": "^1.0.9"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,20 +1,9 @@
 {
   "name": "homebridge-fritz",
-  "version": "0.2.5",
+  "version": "0.3.0",
+  "author": "Andreas Goetz <cpuidle@gmx.de>",
+  "homepage": "https://github.com/andig/homebridge-fritz#readme",
   "description": "Homebridge platform plugin for Fritz!Box",
-  "license": "MIT",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\""
-  },
-  "engines": {
-    "node": ">4.0.0",
-    "homebridge": ">=0.3.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/andig/homebridge-fritz.git"
-  },
   "keywords": [
     "homebridge-plugin",
     "homebridge",
@@ -24,15 +13,29 @@
     "homekit",
     "Siri"
   ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/andig/homebridge-fritz.git"
+  },
+  "bugs": {
+    "url": "https://github.com/andig/homebridge-fritz/issues"
+  },
+  "main": "index.js",
+  "scripts": {
+    "test": "node_modules/jshint/bin/jshint index.js"
+  },
+  "engines": {
+    "node": ">4.0.0",
+    "homebridge": ">=0.3.0"
+  },
   "dependencies": {
     "bluebird": "^3.3.5",
     "extend": "^3.0.0",
     "smartfritz-promise": "^0.6.1",
     "valid-url": "^1.0.9"
   },
-  "author": "Andreas Goetz <cpuidle@gmx.de>",
-  "bugs": {
-    "url": "https://github.com/andig/homebridge-fritz/issues"
-  },
-  "homepage": "https://github.com/andig/homebridge-fritz#readme"
+  "devDependencies": {
+    "jshint": "^2.9.2"
+  }
 }


### PR DESCRIPTION
Add support for:
- switch groups (https://github.com/andig/homebridge-fritz/issues/8)
- DECT 100 repeater temperature sensors (https://github.com/andig/homebridge-fritz/issues/7)
