### PR TITLE
Add LED lightbulb support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Homebridge platform plugin for FRITZ!Box.
 This plugin exposes:
 
   - WLAN guest access switch
+  - status LEDs as a lightbulb
+    - ON with >50% brightness: the LEDs are always on and are showing the current status of the Fritz!Box.
+    - ON with <=50% brightness: the LEDs will automatically turn off after a few minutes and stay that way during normal operation. They will light up again in case of an error or a status event.
+    - OFF: the LEDs are always off and will not show any status informations (even in the case of a Fritz!Box error).
   - Fritz!DECT outlets (200, 210)
   - Fritz!Powerline outlets (510, 540)
   - Fritz!DECT (300) and Comet!DECT thermostats
@@ -41,7 +45,7 @@ Add platform to `config.json`, for configuration see below.
       "password": "<password>",
       "url": "http://fritz.box",
       "interval": 60,
-      "hide": ["wifi", "<ain>"],
+      "hide": ["wifi", "led", "<ain>"],
       "concurrent": false,
       "wifiName: "Guest WLAN",
       "options": {
@@ -61,7 +65,7 @@ The following settings are optional:
   - `concurrent`: allow concurrent api requests for newer Fritz!BOXes with better performance (experimental)
   - `wifiName`: custom name for the WLAN guest access switch (fallback `Guest WLAN`)
 
-The `hide` config options allows to specify an array of device AINs that will not be added to homebridge. Use `wifi` for hiding the WLAN guest access switch.
+The `hide` config options allows to specify an array of device AINs that will not be added to homebridge. Use `wifi` for hiding the WLAN guest access or `led` for hiding the led lightbulb.
 
 
 ## Common Issues / Frequently Asked Questions

--- a/lib/accessories/led.js
+++ b/lib/accessories/led.js
@@ -1,0 +1,100 @@
+/**
+ * FritzLEDAccessory
+ *
+ * @url https://github.com/andig/homebridge-fritz
+ * @author Andreas Götz <cpuidle@gmx.de>
+ * @license MIT
+ */
+
+/* jslint node: true, laxcomma: true, esversion: 6 */
+"use strict";
+
+var Service, Characteristic, FritzPlatform;
+
+module.exports = function(homebridge) {
+    Service = homebridge.hap.Service;
+    Characteristic = homebridge.hap.Characteristic;
+
+    FritzPlatform = require('../platform')(homebridge);
+
+    return FritzLEDAccessory;
+};
+
+function FritzLEDAccessory(platform) {
+    this.platform = platform;
+    this.name = "LED status";
+
+    this.services = {
+        AccessoryInformation: new Service.AccessoryInformation(),
+        Lightbulb: new Service.Lightbulb(this.name)
+    };
+
+    this.services.AccessoryInformation.setCharacteristic(Characteristic.Manufacturer, "AVM");
+    this.services.AccessoryInformation.setCharacteristic(Characteristic.Model, "Fritz!Box");
+
+    this.platform.fritz('getOSVersion').then(function(version) {
+        this.services.AccessoryInformation.setCharacteristic(Characteristic.FirmwareRevision, version);
+    }.bind(this));
+
+    this.services.Lightbulb.getCharacteristic(Characteristic.On).on('set', this.setOn.bind(this));
+    this.services.Lightbulb.getCharacteristic(Characteristic.Brightness).on('set', this.setBrightness.bind(this));
+
+    setImmediate(this.update.bind(this));
+}
+
+FritzLEDAccessory.prototype.getServices = function() {
+    return [this.services.AccessoryInformation, this.services.Lightbulb];
+};
+
+FritzLEDAccessory.prototype.setOn = function(on, callback, context) {
+    var service = this.services.Lightbulb;
+    var platform = this.platform;
+
+    // changing brightness will immediately emit setOn(true), which we ignore here
+    if (context == FritzPlatform.Context || service.updatePending) {
+        callback(null);
+        return;
+    }
+
+    platform.log("Switching LED on to: " + on);
+
+    this.services.Lightbulb.getCharacteristic(Characteristic.Brightness).getValue(function(err, brightness){
+        platform.fritz('setLEDStatus', on ? (brightness > 50 ? '0' : '1') : '2').then(function(res) {
+            service.fritzState = res.led_display;
+            platform.log("New LED status: " + res.led_display);
+            callback(null);
+        });
+    }, FritzPlatform.Context);
+};
+
+FritzLEDAccessory.prototype.setBrightness = function(brightness, callback, context) {
+    var service = this.services.Lightbulb;
+    var plog = this.platform.log;
+
+    if (context == FritzPlatform.Context) {
+        callback(null);
+        return;
+    }
+
+    plog("Switching LED brightness to: " + brightness);
+    service.updatePending = true;
+
+    this.platform.fritz('setLEDStatus', brightness > 50 ? '0' : (brightness > 0 ? '1' : '2')).then(function(res) {
+        service.fritzState = res.led_display;
+        service.updatePending = false;
+        plog("New LED status: " + res.led_display);
+        callback(null);
+    });
+};
+
+FritzLEDAccessory.prototype.update = function() {
+    var service = this.services.Lightbulb;
+    var plog = this.platform.log;
+
+    this.platform.fritz('getLEDStatus').then(function(res) {
+        service.fritzState = res.led_display;
+        plog("initial LED status: " + res.led_display);
+        service.getCharacteristic(Characteristic.On).setValue(res.led_display !== '2', undefined, FritzPlatform.Context);
+        service.getCharacteristic(Characteristic.Brightness).setValue(res.led_display === '1' ? 10 : 100, undefined, FritzPlatform.Context);
+    });
+};

--- a/lib/accessories/thermostat.js
+++ b/lib/accessories/thermostat.js
@@ -150,7 +150,7 @@ FritzThermostatAccessory.prototype.getCurrentAutoTemperature = function() {
 
         // if next change is to comfort temp, we are in night mode
         /* jshint laxbreak:true */
-        return fritz.api2temp(hkr.nextchange.tchange === hkr.komfort
+        return self.platform.api2temp(hkr.nextchange.tchange === hkr.komfort
             ? hkr.absenk
             : hkr.komfort
         );

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -91,6 +91,12 @@ FritzPlatform.prototype = {
                 accessories.push(new FritzWifiAccessory(self));
             }
 
+            // led
+            if (self.config.hide.indexOf("led") == -1) {
+                let FritzLEDAccessory = require('./accessories/led')(Homebridge);
+                accessories.push(new FritzLEDAccessory(self));
+            }
+
             self.updateDeviceList().then(function(devices) {
                 var jobs = [];
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/jshint/bin/jshint index.js"
+    "test": "node_modules/jshint/bin/jshint index.js lib"
   },
   "engines": {
     "node": ">4.0.0",


### PR DESCRIPTION
This PR makes it possible to control the status LEDs of a Fritz!Box as a lightbulb (because they are a real lightbulb as everyone sleeping in the same room will know 😉).

You can control the status LEDs with the following lightbulb settings in homekit:
* ON with >50% brightness: the LEDs are always on and are showing the current status of the Fritz!Box.
* ON with <=50% brightness: the LEDs will automatically turn off after a few minutes and stay that way during normal operation. They will light up again in case of an error or a status event.
* OFF: the LEDs are always off and will not show any status informations (even in the case of a Fritz!Box error).

It depends on the corresponding `fritzapi` PR: https://github.com/andig/fritzapi/pull/7

The second commit https://github.com/andig/homebridge-fritz/commit/3071f03e2082bc76ecd7583d4745fa3eafe75127 fixes also a bug introduced [in the latest refactor](https://github.com/andig/homebridge-fritz/commit/11046ecc34eff0c07b42fe27d49f1c0bc07cf08a#diff-efbe59ec90598b8175b62f7b2ffaa286R153) and adds the `lib` folder to the linting to prevent such bugs in the future.

Tested with a Fritz!Box 6490 and FRITZ!OS 6.87.