### PR TITLE
Fix config JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add platform to `config.json`, for configuration see below.
       "interval": 60,
       "hide": ["wifi", "<ain>"],
       "concurrent": false,
-      "wifiName: "Guest WLAN",
+      "wifiName": "Guest WLAN",
       "options": {
         "strictSSL": false
       }


### PR DESCRIPTION
There was a missing `"` in the example config.