### PR TITLE
Fritz!OS 7: use wlanconfig2 instead of wlanconfig3

### DIFF
--- a/lib/accessories/wifi.js
+++ b/lib/accessories/wifi.js
@@ -73,7 +73,7 @@ function FritzWifiAccessory(platform) {
 
             // remember service
             let wifiService = "urn:dslforum-org:service:WLANConfiguration";
-            this.tr64service = tr64.services[wifiService + ":3"] || tr64.services[wifiService + ":2"];
+            this.tr64service = tr64.services[wifiService + ":2"];
 
             this.services.Switch.getCharacteristic(Characteristic.On)
                 .on('get', this.getOn.bind(this))


### PR DESCRIPTION
Fritz!OS 07.01 (tested on a 7590) produces the following error for the `urn:dslforum-org:service:WLANConfiguration:3#GetInfo` action on the `/upnp/control/wlanconfig3` endpoint:
```
<?xml version="1.0"?>
<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
<s:Body>
<s:Fault>
<faultcode>s:Client</faultcode>
<faultstring>UPnPError</faultstring>
<detail>
<UPnPError xmlns="urn:dslforum-org:control-1-0">
<errorCode>504</errorCode>
<errorDescription>Unknown Error Code</errorDescription>
</UPnPError>
</detail>
</s:Fault>
</s:Body>
</s:Envelope>
```
Work around this by using the `wlanconfig2` endpoint which does not appear to have this problem.

Fixes #49.