### PR TITLE
Fix #39 Auto-Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ The `hide` config options allows to specify an array of device AINs that will no
       Battery charge is not an API function. That means that the user must have access to FritzBox administration, not only to the SmartHome API in order to use this functionality. 
       Update your Fritz!Box user accordingly. 
 
+  4. homebridge-fritz thermostat tips for Modes and Scenes in Home App
+      
+      When Scenes are used in the Home App, a target temperature and mode have to be set. There are the modes Off, Heating, Cooling and Auto. Auto works best for Scenes.
+      - Off - turns the Thermostat off
+      - Heating/Cooling - sets the target temperature to the comfort/setback setting of your Fritz!Box. Your personal choice will be overwritten
+      - Auto - only sets your chosen target temperature
 
 ## Debugging
 

--- a/lib/accessories/thermostat.js
+++ b/lib/accessories/thermostat.js
@@ -124,8 +124,8 @@ FritzThermostatAccessory.prototype.setTargetHeatingCoolingState = function(state
             promise = this.platform.fritz('getTempComfort', this.ain);
             break;
         case Characteristic.TargetHeatingCoolingState.AUTO:
-            promise = this.getCurrentAutoTemperature();
-            break;
+            callback(null, state);
+            return;
     }
 
     promise.then(function(temp) {

--- a/lib/accessories/thermostat.js
+++ b/lib/accessories/thermostat.js
@@ -137,26 +137,6 @@ FritzThermostatAccessory.prototype.setTargetHeatingCoolingState = function(state
     });
 };
 
-FritzThermostatAccessory.prototype.getCurrentAutoTemperature = function() {
-    var self = this;
-    return this.platform.updateDeviceList().then(function() {
-        var device = self.platform.getDevice(self.ain);
-        if (!device.hkr) {
-            self.platform.log.error('Could not get thermostat schedule. Fritz!OS outdated?');
-            return;
-        }
-
-        var hkr = device.hkr;
-
-        // if next change is to comfort temp, we are in night mode
-        /* jshint laxbreak:true */
-        return self.platform.fritzApi().api2temp(hkr.nextchange.tchange === hkr.komfort
-            ? hkr.absenk
-            : hkr.komfort
-        );
-    });
-};
-
 FritzThermostatAccessory.prototype.getTargetTemperature = function(callback) {
     this.platform.log(`Getting ${this.type} ${this.ain} target temperature`);
 


### PR DESCRIPTION
Without getCurrentAutoTemperature in setTargetHeatingCoolingState temperatures don't switch back anymore when using scenes/automation.

Works for me:
- 6490 Cable, FritzOS 7.0
- iOS 12.1.2
- CometDECT