### PR TITLE
Restrict characteristic values for thermostat to be valid and enforce HomeKit thermostat behavior

### DIFF
--- a/lib/accessories/thermostat.js
+++ b/lib/accessories/thermostat.js
@@ -35,9 +35,11 @@ function FritzThermostatAccessory(platform, ain) {
 
     // Thermostat
     this.services.Thermostat.getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+        .setProps({validValues: [0, 1]})
         .on('get', this.getCurrentHeatingCoolingState.bind(this))
     ;
     this.services.Thermostat.getCharacteristic(Characteristic.TargetHeatingCoolingState)
+        .setProps({validValues: [0, 1]}) // only support "off" and "heating"
         .on('get', this.getTargetHeatingCoolingState.bind(this))
         .on('set', this.setTargetHeatingCoolingState.bind(this))
     ;
@@ -46,6 +48,7 @@ function FritzThermostatAccessory(platform, ain) {
         .on('get', this.getCurrentTemperature.bind(this))
     ;
     this.services.Thermostat.getCharacteristic(Characteristic.TargetTemperature)
+        .setProps({validValueRanges: [8, 28], minValue: 8, maxValue: 28}) // supported temperature range of fritz thermostat
         .on('get', this.getTargetTemperature.bind(this))
         .on('set', this.setTargetTemperature.bind(this))
     ;
@@ -69,7 +72,7 @@ function FritzThermostatAccessory(platform, ain) {
     this.services.BatteryService.fritzBatteryLevel = 100;
     this.services.BatteryService.fritzStatusLowBattery = Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL;
     this.services.Thermostat.fritzCurrentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.OFF;
-    this.services.Thermostat.fritzTargetHeatingCoolingState = Characteristic.TargetHeatingCoolingState.AUTO;
+    this.services.Thermostat.fritzTargetHeatingCoolingState = Characteristic.TargetHeatingCoolingState.OFF;
     this.services.Thermostat.fritzTargetTemperature = 20;
 
     this.update(); // execute immediately to get first initial values as fast as possible
@@ -97,22 +100,13 @@ FritzThermostatAccessory.prototype.setTargetHeatingCoolingState = function(state
 
     service.fritzTargetHeatingCoolingState = state;
 
-    let currentState = Characteristic.CurrentHeatingCoolingState.HEAT;
-    // noinspection FallThroughInSwitchStatementJS
-    switch (state) {
-        case Characteristic.TargetHeatingCoolingState.COOL:
-            currentState = Characteristic.CurrentHeatingCoolingState.COOL;
-            // fall through to the next
-        case Characteristic.TargetHeatingCoolingState.HEAT:
-            this.queryNightAndComfortTemperatures(true);
-            break;
-        case Characteristic.TargetHeatingCoolingState.OFF:
-            this.platform.fritz("setTempTarget", this.ain, "off");
-            currentState = Characteristic.CurrentHeatingCoolingState.OFF;
-            break;
-        case Characteristic.TargetHeatingCoolingState.AUTO:
-            this.platform.fritz("setTempTarget", this.ain, service.fritzTargetTemperature);
-            break;
+    let currentState;
+    if (state === Characteristic.TargetHeatingCoolingState.OFF) {
+        this.platform.fritz("setTempTarget", this.ain, "off");
+        currentState = Characteristic.CurrentHeatingCoolingState.OFF;
+    } else if (state === Characteristic.TargetHeatingCoolingState.HEAT) {
+        this.platform.fritz("setTempTarget", this.ain, service.fritzTargetTemperature);
+        currentState = this.calculateCurrentHeatingCoolingState();
     }
 
     service.fritzCurrentHeatingCoolingState = currentState;
@@ -135,16 +129,13 @@ FritzThermostatAccessory.prototype.setTargetTemperature = function(temperature, 
     const service = this.services.Thermostat;
 
     service.fritzTargetTemperature = temperature;
-    service.fritzTargetHeatingCoolingState = Characteristic.TargetHeatingCoolingState.AUTO;
-    service.fritzCurrentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.HEAT;
+    service.fritzTargetHeatingCoolingState = Characteristic.TargetHeatingCoolingState.HEAT;
+    service.fritzCurrentHeatingCoolingState = this.calculateCurrentHeatingCoolingState();
 
     service.getCharacteristic(Characteristic.TargetHeatingCoolingState).updateValue(service.fritzTargetHeatingCoolingState);
     service.getCharacteristic(Characteristic.CurrentHeatingCoolingState).updateValue(service.fritzCurrentHeatingCoolingState);
 
-    this.platform.fritz('setTempTarget', this.ain, temperature).then(temperature => {
-
-        service.getCharacteristic(Characteristic.TargetTemperature).updateValue(temperature);
-    });
+    this.platform.fritz('setTempTarget', this.ain, temperature);
 
     callback();
 };
@@ -158,56 +149,39 @@ FritzThermostatAccessory.prototype.queryTargetTemperature = function() {
         const service = this.services.Thermostat;
 
         let targetTemperature = temperature;
-        let currentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.HEAT;
-        let targetHeatingCoolingState = service.fritzTargetHeatingCoolingState; // only changes when temperature reads 'off'
+        let currentHeatingCoolingState;
+        let targetHeatingCoolingState = Characteristic.TargetHeatingCoolingState.HEAT;
+
+        if (temperature === "on") { // change to hap representable value if thermostat is set to on permanently
+            targetTemperature = service.getCharacteristic(Characteristic.TargetTemperature).props.maxValue;
+        }
 
         if (temperature === "off") {
             targetTemperature = service.fritzTargetTemperature;
             currentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.OFF;
             targetHeatingCoolingState = Characteristic.TargetHeatingCoolingState.OFF;
-        } else if (temperature === "on") {
-            targetTemperature = service.getCharacteristic(Characteristic.TargetTemperature).props.maxValue;
+        } else {
+            currentHeatingCoolingState = this.calculateCurrentHeatingCoolingState();
         }
 
-        if (targetHeatingCoolingState === Characteristic.TargetHeatingCoolingState.COOL) {
-            currentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.COOL;
-        }
-
+        service.fritzTargetTemperature = targetTemperature;
         service.fritzCurrentHeatingCoolingState = currentHeatingCoolingState;
         service.fritzTargetHeatingCoolingState = targetHeatingCoolingState;
 
         service.getCharacteristic(Characteristic.CurrentHeatingCoolingState).updateValue(currentHeatingCoolingState);
         service.getCharacteristic(Characteristic.TargetHeatingCoolingState).updateValue(targetHeatingCoolingState);
-
-        if (targetHeatingCoolingState !== Characteristic.TargetHeatingCoolingState.COOL
-            && targetHeatingCoolingState !== Characteristic.TargetHeatingCoolingState.HEAT) {
-            service.fritzTargetTemperature = targetTemperature;
-            service.getCharacteristic(Characteristic.TargetTemperature).updateValue(targetTemperature);
-        }
+        service.getCharacteristic(Characteristic.TargetTemperature).updateValue(targetTemperature);
     });
 };
 
-FritzThermostatAccessory.prototype.queryNightAndComfortTemperatures = function(sendTargetTempUpdate) {
+FritzThermostatAccessory.prototype.calculateCurrentHeatingCoolingState = function() {
     const service = this.services.Thermostat;
-    const targetHeatingCoolingState = service.fritzTargetHeatingCoolingState;
 
-    let func = undefined;
-    if (targetHeatingCoolingState === Characteristic.TargetHeatingCoolingState.COOL) {
-        func = "getTempNight";
-    } else if (targetHeatingCoolingState === Characteristic.TargetHeatingCoolingState.HEAT) {
-        func = "getTempComfort";
-    } else {
-        return;
-    }
-
-    this.platform.fritz(func, this.ain).then(temperature => {
-        service.fritzTargetTemperature = temperature; // overwrite the current temperature
-        service.getCharacteristic(Characteristic.TargetTemperature).updateValue(temperature);
-
-        if (sendTargetTempUpdate) {
-            this.platform.fritz("setTempTarget", this.ain, temperature);
-        }
-    });
+    // getCurrentTemperature was probably executed before (see #update); so it's enough to use the cached value
+    const currentTemperature = service.fritzCurrentTemperature;
+    return currentTemperature <= service.fritzTargetTemperature // we are guessing the current state of the valve
+        ? Characteristic.CurrentHeatingCoolingState.HEAT
+        : Characteristic.CurrentHeatingCoolingState.OFF;
 };
 
 FritzThermostatAccessory.prototype.getBatteryLevel = function(callback) {
@@ -248,6 +222,5 @@ FritzThermostatAccessory.prototype.update = function() {
 
     this.queryCurrentTemperature();
     this.queryTargetTemperature();
-    this.queryNightAndComfortTemperatures(false);
     this.queryBatteryLevel();
 };


### PR DESCRIPTION
This PR makes the following changes. It enforces the behavior of a thermostat as it is defined by the HomeKit Accessory Protocol spec. This means the thermostat supports exact two states: heating and off (as the fritz thermostats are only able to heat and definitely can't support cooling).
Also this PR properly defines the minimum and maximum temperatures the fritz thermostat is able to support (from 8-28 degree Celsius).
This PR also improves data collection for thermostats on first startup.

Any feedback is appreciated :)

~ Andi (lol)