### PR TITLE
Migrating code to use updateValue instead of setValue for state changes

### DIFF
--- a/lib/accessories/alarmsensor.js
+++ b/lib/accessories/alarmsensor.js
@@ -9,10 +9,10 @@
 /* jslint node: true, laxcomma: true, esversion: 6 */
 "use strict";
 
-var inherits = require('util').inherits;
-var extend = require('extend');
+const inherits = require('util').inherits;
+const extend = require('extend');
 
-var Service, Characteristic, FritzPlatform, FritzAccessory;
+let Service, Characteristic, FritzPlatform, FritzAccessory;
 
 module.exports = function(homebridge) {
     Service = homebridge.hap.Service;
@@ -36,32 +36,35 @@ function FritzAlarmSensorAccessory(platform, ain) {
         .on('get', this.getSensorState.bind(this))
     ;
 
+    this.update(); // execute immediately to get first initial values as fast as possible
     setInterval(this.update.bind(this), this.platform.interval);
 }
 
 FritzAlarmSensorAccessory.prototype.getSensorState = function(callback) {
     this.platform.log(`Getting ${this.type} ${this.ain} alarm state`);
-    var self = this;
 
-    var service = this.services.ContactSensor;
-    callback(null, service.fritzAlarmState);
+    callback(null, this.services.ContactSensor.fritzAlarmState);
+    this.querySensorState();
+};
 
-    this.platform.fritz('getDeviceListFiltered', { identifier: this.ain }).then(function(devices) {
-        var state = +devices[0].alert.state ? Characteristic.ContactSensorState.CONTACT_NOT_DETECTED : Characteristic.ContactSensorState.CONTACT_DETECTED;
+FritzAlarmSensorAccessory.prototype.querySensorState = function() {
+    this.platform.fritz('getDeviceListFiltered', { identifier: this.ain }).then(devices => {
+        const service = this.services.ContactSensor;
+        let state = +devices[0].alert.state
+            ? Characteristic.ContactSensorState.CONTACT_NOT_DETECTED
+            : Characteristic.ContactSensorState.CONTACT_DETECTED;
 
         // invert if enabled
-        state = self.platform.deviceConfig(`${self.ain}.invert`, false) ? 1-state : state
+        state = self.platform.deviceConfig(`${self.ain}.invert`, false)
+            ? 1-state
+            : state;
 
         service.fritzAlarmState = state;
-        service.getCharacteristic(Characteristic.ContactSensorState).setValue(state, undefined, FritzPlatform.Context);
+        service.getCharacteristic(Characteristic.ContactSensorState).updateValue(state);
     });
 };
 
 FritzAlarmSensorAccessory.prototype.update = function() {
     this.platform.log(`Updating ${this.type} ${this.ain}`);
-
-    // ContactSensor
-    this.getSensorState(function(foo, state) {
-        this.services.ContactSensor.getCharacteristic(Characteristic.ContactSensorState).setValue(foo, undefined, FritzPlatform.Context);
-    }.bind(this));
+    this.querySensorState();
 };

--- a/lib/accessories/outlet.js
+++ b/lib/accessories/outlet.js
@@ -9,10 +9,10 @@
 /* jslint node: true, laxcomma: true, esversion: 6 */
 "use strict";
 
-var inherits = require('util').inherits;
-var extend = require('extend');
+const inherits = require('util').inherits;
+const extend = require('extend');
 
-var Service, Characteristic, FritzPlatform, FritzAccessory;
+let Service, Characteristic, FritzPlatform, FritzAccessory;
 
 module.exports = function(homebridge) {
     Service = homebridge.hap.Service;
@@ -62,104 +62,97 @@ function FritzOutletAccessory(platform, ain) {
             .setProps({minValue: -50})
             .on('get', this.getCurrentTemperature.bind(this))
         ;
+
+        this.services.TemperatureSensor.fritzCurrentTemperature = 20;
     }
 
+    this.services.Outlet.fritzState = false;
+    this.services.Outlet.fritzInUse = false;
+    this.services.Outlet.fritzPowerUsage = 0;
+    this.services.Outlet.fritzEnergyConsumption = 0;
+
+    this.update(); // execute immediately to get first initial values as fast as possible
     setInterval(this.update.bind(this), this.platform.interval);
 }
 
 FritzOutletAccessory.prototype.getOn = function(callback) {
     this.platform.log(`Getting ${this.type} ${this.ain} state`);
 
-    var service = this.services.Outlet;
-    callback(null, service.fritzState);
+    callback(null, this.services.Outlet.fritzState);
 
-    this.platform.fritz('getSwitchState', this.ain).then(function(state) {
-        service.fritzState = state;
-        service.getCharacteristic(Characteristic.On).setValue(state, undefined, FritzPlatform.Context);
-    });
+    this.queryOn();
 };
 
-FritzOutletAccessory.prototype.setOn = function(state, callback, context) {
-    var service = this.services.Outlet;
-    service.fritzState = state;
-
-    callback(null, state);
-
-    if (context == FritzPlatform.Context) {
-        return;
-    }
-
+FritzOutletAccessory.prototype.setOn = function(state, callback) {
     this.platform.log(`Switching ${this.type} ${this.ain} to ` + state);
 
-    var func = state ? 'setSwitchOn' : 'setSwitchOff';
-    this.platform.fritz(func, this.ain).then(function(state) {
-        service.getCharacteristic(Characteristic.On).setValue(state, undefined, FritzPlatform.Context)
+    this.services.Outlet.fritzState = state;
+    this.platform.fritz(state ? 'setSwitchOn' : 'setSwitchOff', this.ain);
+
+    callback();
+};
+
+FritzOutletAccessory.prototype.queryOn = function() {
+    this.platform.fritz('getSwitchState', this.ain).then(state => {
+        const service = this.services.Outlet;
+        service.fritzState = state;
+        service.getCharacteristic(Characteristic.On).updateValue(state);
     });
 };
 
 FritzOutletAccessory.prototype.getInUse = function(callback) {
     this.platform.log(`Getting ${this.type} ${this.ain} in use`);
 
-    var service = this.services.Outlet;
-    callback(null, service.fritzInUse);
-
-    this.platform.fritz('getSwitchPower', this.ain).then(function(power) {
-        var inUse = power > 0;
-        service.fritzInUse = inUse;
-        service.getCharacteristic(Characteristic.OutletInUse).setValue(inUse, undefined, FritzPlatform.Context);
-    });
+    callback(null, this.services.Outlet.fritzInUse);
+    this.queryPowerUsage();
 };
 
 FritzOutletAccessory.prototype.getPowerUsage = function(callback) {
     this.platform.log(`Getting ${this.type} ${this.ain} power usage`);
 
-    var service = this.services.Outlet;
-    callback(null, service.fritzPowerUsage);
+    callback(null, this.services.Outlet.fritzPowerUsage);
+    this.queryPowerUsage();
+};
 
-    this.platform.fritz('getSwitchPower', this.ain).then(function(power) {
+FritzOutletAccessory.prototype.queryPowerUsage = function() {
+    this.platform.fritz('getSwitchPower', this.ain).then(power => {
+        const service = this.services.Outlet;
+
+        service.fritzInUse = power > 0;
         service.fritzPowerUsage = power;
-        service.getCharacteristic(FritzPlatform.PowerUsage).setValue(power, undefined, FritzPlatform.Context);
+
+        service.getCharacteristic(Characteristic.OutletInUse).updateValue(service.fritzInUse);
+        service.getCharacteristic(FritzPlatform.PowerUsage).updateValue(power);
     });
 };
 
 FritzOutletAccessory.prototype.getEnergyConsumption = function(callback) {
     this.platform.log(`Getting ${this.type} ${this.ain} energy consumption`);
 
-    var service = this.services.Outlet;
-    callback(null, service.fritzEnergyConsumption);
+    callback(null, this.services.Outlet.fritzEnergyConsumption);
+    this.queryEnergyConsumption();
+};
 
-    this.platform.fritz('getSwitchEnergy', this.ain).then(function(energy) {
+FritzOutletAccessory.prototype.queryEnergyConsumption = function() {
+    this.platform.fritz('getSwitchEnergy', this.ain).then(energy => {
+        const service = this.services.Outlet;
+
         energy = energy / 1000.0;
         service.fritzEnergyConsumption = energy;
-        service.getCharacteristic(FritzPlatform.EnergyConsumption).setValue(energy, undefined, FritzPlatform.Context);
+        service.getCharacteristic(FritzPlatform.EnergyConsumption).updateValue(energy);
     });
 };
 
 FritzOutletAccessory.prototype.update = function() {
     this.platform.log(`Updating ${this.type} ${this.ain}`);
-    var self = this;
 
     // Outlet
-    this.getOn(function(foo, state) {
-        self.services.Outlet.getCharacteristic(Characteristic.On).setValue(state, undefined, FritzPlatform.Context);
-    }.bind(this));
-
-    this.getPowerUsage(function(foo, power) {
-        self.services.Outlet.getCharacteristic(FritzPlatform.PowerUsage).setValue(power, undefined, FritzPlatform.Context);
-    }.bind(this));
-
-    this.getInUse(function(foo, state) {
-        self.services.Outlet.getCharacteristic(Characteristic.OutletInUse).setValue(state, undefined, FritzPlatform.Context);
-    }.bind(this));
-
-    this.getEnergyConsumption(function(foo, energy) {
-        self.services.Outlet.getCharacteristic(FritzPlatform.EnergyConsumption).setValue(energy, undefined, FritzPlatform.Context);
-    }.bind(this));
+    this.queryOn();
+    this.queryPowerUsage();
+    this.queryEnergyConsumption();
 
     // TemperatureSensor
     if (this.services.TemperatureSensor) {
-        this.getCurrentTemperature(function(foo, temp) {
-            self.services.TemperatureSensor.getCharacteristic(Characteristic.CurrentTemperature).setValue(temp, undefined, FritzPlatform.Context);
-        }.bind(this));
+        this.queryCurrentTemperature();
     }
 };

--- a/lib/accessories/temperaturesensor.js
+++ b/lib/accessories/temperaturesensor.js
@@ -9,10 +9,10 @@
 /* jslint node: true, laxcomma: true, esversion: 6 */
 "use strict";
 
-var inherits = require('util').inherits;
-var extend = require('extend');
+const inherits = require('util').inherits;
+const extend = require('extend');
 
-var Service, Characteristic, FritzPlatform, FritzAccessory;
+let Service, Characteristic, FritzPlatform, FritzAccessory;
 
 module.exports = function(homebridge) {
     Service = homebridge.hap.Service;
@@ -37,14 +37,13 @@ function FritzTemperatureSensorAccessory(platform, ain) {
         .on('get', this.getCurrentTemperature.bind(this))
     ;
 
+    this.services.TemperatureSensor.fritzCurrentTemperature = 20;
+
+    this.update(); // execute immediately to get first initial values as fast as possible
     setInterval(this.update.bind(this), this.platform.interval);
 }
 
 FritzTemperatureSensorAccessory.prototype.update = function() {
     this.platform.log(`Updating ${this.type} ${this.ain}`);
-
-    // TemperatureSensor
-    this.getCurrentTemperature(function(foo, temp) {
-        this.services.TemperatureSensor.getCharacteristic(Characteristic.CurrentTemperature).setValue(temp, undefined, FritzPlatform.Context);
-    }.bind(this));
+    this.queryCurrentTemperature();
 };

--- a/lib/accessories/thermostat.js
+++ b/lib/accessories/thermostat.js
@@ -9,10 +9,10 @@
 /* jslint node: true, laxcomma: true, esversion: 6 */
 "use strict";
 
-var inherits = require('util').inherits;
-var extend = require('extend');
+const inherits = require('util').inherits;
+const extend = require('extend');
 
-var Service, Characteristic, FritzPlatform, FritzAccessory;
+let Service, Characteristic, FritzPlatform, FritzAccessory;
 
 module.exports = function(homebridge) {
     Service = homebridge.hap.Service;
@@ -64,119 +64,150 @@ function FritzThermostatAccessory(platform, ain) {
         .on('get', this.getStatusLowBattery.bind(this))
     ;
 
+    // init some default values until the first update response arrives
+    this.services.Thermostat.fritzCurrentTemperature = 20;
+    this.services.BatteryService.fritzBatteryLevel = 100;
+    this.services.BatteryService.fritzStatusLowBattery = Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL;
+    this.services.Thermostat.fritzCurrentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.OFF;
+    this.services.Thermostat.fritzTargetHeatingCoolingState = Characteristic.TargetHeatingCoolingState.AUTO;
+    this.services.Thermostat.fritzTargetTemperature = 20;
+
+    this.update(); // execute immediately to get first initial values as fast as possible
     setInterval(this.update.bind(this), this.platform.interval);
 }
 
 FritzThermostatAccessory.prototype.getCurrentHeatingCoolingState = function(callback) {
     this.platform.log(`Getting ${this.type} ${this.ain} current heating state`);
 
-    var service = this.services.Thermostat;
-    callback(null, service.fritzCurrentHeatingCoolingState);
-
-    this.platform.fritz('getTempTarget', this.ain).then(function(temp) {
-        var state = temp == 'off' ? Characteristic.CurrentHeatingCoolingState.OFF : Characteristic.CurrentHeatingCoolingState.HEAT;
-
-        service.fritzCurrentHeatingCoolingState = state;
-        service.getCharacteristic(Characteristic.CurrentHeatingCoolingState).setValue(state, undefined, FritzPlatform.Context);
-    });
+    // current state gets queried in getTargetTemperature
+    callback(null, this.services.Thermostat.fritzCurrentHeatingCoolingState);
 };
 
 FritzThermostatAccessory.prototype.getTargetHeatingCoolingState = function(callback) {
     this.platform.log(`Getting ${this.type} ${this.ain} target heating state`);
 
-    var service = this.services.Thermostat;
-    callback(null, service.fritzTargetHeatingCoolingState);
-
-    this.platform.fritz('getTempTarget', this.ain).then(function(temp) {
-        var state;
-
-        switch (temp) {
-            case 'off':
-                state = Characteristic.TargetHeatingCoolingState.OFF;
-                break;
-            case 'on':
-                state = Characteristic.TargetHeatingCoolingState.HEAT;
-                break;
-            default:
-                state = Characteristic.TargetHeatingCoolingState.AUTO;
-        }
-
-        service.getCharacteristic(Characteristic.TargetHeatingCoolingState).setValue(state, undefined, FritzPlatform.Context);
-    });
+    // target state gets queried in getTargetTemperature
+    callback(null, this.services.Thermostat.fritzTargetHeatingCoolingState);
 };
 
-FritzThermostatAccessory.prototype.setTargetHeatingCoolingState = function(state, callback, context) {
-    var service = this.services.Thermostat;
+FritzThermostatAccessory.prototype.setTargetHeatingCoolingState = function(state, callback) {
+    this.platform.log(`Setting ${this.type} ${this.ain} heating state`);
+
+    const service = this.services.Thermostat;
+
     service.fritzTargetHeatingCoolingState = state;
 
-    callback(null, state);
-
-    if (context == FritzPlatform.Context) {
-        return;
-    }
-
-    this.platform.log(`Setting ${this.type} ${this.ain} heating state`);
-    var self = this, promise;
-
+    let currentState = Characteristic.CurrentHeatingCoolingState.HEAT;
+    // noinspection FallThroughInSwitchStatementJS
     switch (state) {
-        case Characteristic.TargetHeatingCoolingState.OFF:
         case Characteristic.TargetHeatingCoolingState.COOL:
-            promise = this.platform.fritz('getTempNight', this.ain);
-            break;
+            currentState = Characteristic.CurrentHeatingCoolingState.COOL;
+            // fall through to the next
         case Characteristic.TargetHeatingCoolingState.HEAT:
-            promise = this.platform.fritz('getTempComfort', this.ain);
+            this.queryNightAndComfortTemperatures(true);
+            break;
+        case Characteristic.TargetHeatingCoolingState.OFF:
+            this.platform.fritz("setTempTarget", this.ain, "off");
+            currentState = Characteristic.CurrentHeatingCoolingState.OFF;
             break;
         case Characteristic.TargetHeatingCoolingState.AUTO:
-            // let the Fritz!Box do its job
-            return;
+            this.platform.fritz("setTempTarget", this.ain, service.fritzTargetTemperature);
+            break;
     }
 
-    promise.then(function(temp) {
-        if (temp === undefined) {
-            return;
-        }
+    service.fritzCurrentHeatingCoolingState = currentState;
+    service.getCharacteristic(Characteristic.CurrentHeatingCoolingState).updateValue(currentState);
 
-        self.platform.fritz('setTempTarget', self.ain, temp).then(function(temp) {
-            service.getCharacteristic(Characteristic.TargetTemperature).setValue(temp, undefined, FritzPlatform.Context);
-        });
-    });
+    callback();
 };
 
 FritzThermostatAccessory.prototype.getTargetTemperature = function(callback) {
     this.platform.log(`Getting ${this.type} ${this.ain} target temperature`);
 
-    var service = this.services.Thermostat;
-    callback(null, service.fritzTargetTemperature);
+    callback(null, this.services.Thermostat.fritzTargetTemperature);
 
-    this.platform.fritz('getTempTarget', this.ain).then(function(temp) {
-        if (temp == 'off')
-            temp = this.services.Thermostat.getCharacteristic(Characteristic.TargetTemperature).props.minValue;
-        else if (temp == 'on')
-            temp = this.services.Thermostat.getCharacteristic(Characteristic.TargetTemperature).props.maxValue;
-
-        service.getCharacteristic(Characteristic.TargetTemperature).setValue(temp, undefined, FritzPlatform.Context);
-    }.bind(this));
+    this.queryTargetTemperature(); // send query to fritz box; this will also update target/current heating cooling states
 };
 
-FritzThermostatAccessory.prototype.setTargetTemperature = function(temp, callback, context) {
-    var service = this.services.Thermostat;
-    service.fritzTargetTemperature = temp;
-
-    callback(null, temp);
-
-    if (context == FritzPlatform.Context) {
-        return;
-    }
-
+FritzThermostatAccessory.prototype.setTargetTemperature = function(temperature, callback) {
     this.platform.log(`Setting ${this.type} ${this.ain} target temperature`);
-    
-    this.platform.fritz('setTempTarget', this.ain, temp).then(function(temp) {
-        service.getCharacteristic(Characteristic.TargetTemperature).setValue(temp, undefined, FritzPlatform.Context);
+
+    const service = this.services.Thermostat;
+
+    service.fritzTargetTemperature = temperature;
+    service.fritzTargetHeatingCoolingState = Characteristic.TargetHeatingCoolingState.AUTO;
+    service.fritzCurrentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.HEAT;
+
+    service.getCharacteristic(Characteristic.TargetHeatingCoolingState).updateValue(service.fritzTargetHeatingCoolingState);
+    service.getCharacteristic(Characteristic.CurrentHeatingCoolingState).updateValue(service.fritzCurrentHeatingCoolingState);
+
+    this.platform.fritz('setTempTarget', this.ain, temperature).then(temperature => {
+
+        service.getCharacteristic(Characteristic.TargetTemperature).updateValue(temperature);
     });
+
+    callback();
 };
 
 FritzThermostatAccessory.prototype.getTemperatureDisplayUnits = function(callback) {
     callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS);
+};
+
+FritzThermostatAccessory.prototype.queryTargetTemperature = function() {
+    this.platform.fritz('getTempTarget', this.ain).then(temperature => {
+        const service = this.services.Thermostat;
+
+        let targetTemperature = temperature;
+        let currentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.HEAT;
+        let targetHeatingCoolingState = service.fritzTargetHeatingCoolingState; // only changes when temperature reads 'off'
+
+        if (temperature === "off") {
+            targetTemperature = service.fritzTargetTemperature;
+            currentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.OFF;
+            targetHeatingCoolingState = Characteristic.TargetHeatingCoolingState.OFF;
+        } else if (temperature === "on") {
+            targetTemperature = service.getCharacteristic(Characteristic.TargetTemperature).props.maxValue;
+        }
+
+        if (targetHeatingCoolingState === Characteristic.TargetHeatingCoolingState.COOL) {
+            currentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.COOL;
+        }
+
+        service.fritzCurrentHeatingCoolingState = currentHeatingCoolingState;
+        service.fritzTargetHeatingCoolingState = targetHeatingCoolingState;
+
+        service.getCharacteristic(Characteristic.CurrentHeatingCoolingState).updateValue(currentHeatingCoolingState);
+        service.getCharacteristic(Characteristic.TargetHeatingCoolingState).updateValue(targetHeatingCoolingState);
+
+        if (targetHeatingCoolingState !== Characteristic.TargetHeatingCoolingState.COOL
+            && targetHeatingCoolingState !== Characteristic.TargetHeatingCoolingState.HEAT) {
+            service.fritzTargetTemperature = targetTemperature;
+            service.getCharacteristic(Characteristic.TargetTemperature).updateValue(targetTemperature);
+        }
+    });
+};
+
+FritzThermostatAccessory.prototype.queryNightAndComfortTemperatures = function(sendTargetTempUpdate) {
+    const service = this.services.Thermostat;
+    const targetHeatingCoolingState = service.fritzTargetHeatingCoolingState;
+
+    let func = undefined;
+    if (targetHeatingCoolingState === Characteristic.TargetHeatingCoolingState.COOL) {
+        func = "getTempNight";
+    } else if (targetHeatingCoolingState === Characteristic.TargetHeatingCoolingState.HEAT) {
+        func = "getTempComfort";
+    } else {
+        return;
+    }
+
+    this.platform.fritz(func, this.ain).then(temperature => {
+        service.fritzTargetTemperature = temperature; // overwrite the current temperature
+        service.getCharacteristic(Characteristic.TargetTemperature).updateValue(temperature);
+
+        if (sendTargetTempUpdate) {
+            this.platform.fritz("setTempTarget", this.ain, temperature);
+        }
+    });
 };
 
 FritzThermostatAccessory.prototype.getBatteryLevel = function(callback) {
@@ -184,11 +215,6 @@ FritzThermostatAccessory.prototype.getBatteryLevel = function(callback) {
 
     var service = this.services.BatteryService;
     callback(null, service.fritzBatteryLevel);
-
-    this.platform.fritz('getBatteryCharge', this.ain).then(function(batteryLevel) {
-        service.fritzBatteryLevel = batteryLevel;
-        service.getCharacteristic(Characteristic.BatteryLevel).setValue(batteryLevel, undefined, FritzPlatform.Context);
-    });
 };
 
 FritzThermostatAccessory.prototype.getChargingState = function(callback) {
@@ -200,39 +226,28 @@ FritzThermostatAccessory.prototype.getStatusLowBattery = function(callback) {
 
     var service = this.services.BatteryService;
     callback(null, service.fritzStatusLowBattery);
+};
 
-    this.platform.fritz('getBatteryCharge', this.ain).then(function(battery) {
-        /* jshint laxbreak:true */
-        var batteryState = battery < 20
+FritzThermostatAccessory.prototype.queryBatteryLevel = function() {
+    this.platform.fritz('getBatteryCharge', this.ain).then(batteryLevel => {
+        const service = this.services.BatteryService;
+
+        service.fritzBatteryLevel = batteryLevel;
+        service.fritzStatusLowBattery = batteryLevel < 20
             ? Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW
             : Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL;
 
-        service.fritzStatusLowBattery = batteryState;
-        service.getCharacteristic(Characteristic.StatusLowBattery).setValue(batteryState, undefined, FritzPlatform.Context);
+        // update internal value; event get only sent when value changes
+        service.getCharacteristic(Characteristic.BatteryLevel).updateValue(service.fritzBatteryLevel);
+        service.getCharacteristic(Characteristic.StatusLowBattery).updateValue(service.fritzStatusLowBattery);
     });
 };
 
 FritzThermostatAccessory.prototype.update = function() {
     this.platform.log(`Updating ${this.type} ${this.ain}`);
-    var service;
 
-    // Thermostat
-    service = this.services.Thermostat;
-
-    this.getCurrentTemperature(function(foo, temp) {
-        service.getCharacteristic(Characteristic.CurrentTemperature).setValue(temp, undefined, FritzPlatform.Context);
-    });
-    this.getTargetTemperature(function(foo, temp) {
-        service.getCharacteristic(Characteristic.TargetTemperature).setValue(temp, undefined, FritzPlatform.Context);
-    });
-
-    // BatteryService
-    service = this.services.BatteryService;
-
-    this.getBatteryLevel(function(foo, batteryLevel) {
-        service.getCharacteristic(Characteristic.BatteryLevel).setValue(batteryLevel, undefined, FritzPlatform.Context);
-    });
-    this.getStatusLowBattery(function(foo, batteryState) {
-        service.getCharacteristic(Characteristic.StatusLowBattery).setValue(batteryState, undefined, FritzPlatform.Context);
-    });
+    this.queryCurrentTemperature();
+    this.queryTargetTemperature();
+    this.queryNightAndComfortTemperatures(false);
+    this.queryBatteryLevel();
 };

--- a/lib/accessories/wifi.js
+++ b/lib/accessories/wifi.js
@@ -12,7 +12,7 @@
 const url = require("url");
 const TR064 = require("tr-064-async").Fritzbox;
 
-var Service, Characteristic, FritzPlatform;
+let Service, Characteristic, FritzPlatform;
 
 module.exports = function(homebridge) {
     Service = homebridge.hap.Service;
@@ -43,27 +43,29 @@ function FritzWifiAccessory(platform) {
     }.bind(this));
 
     if (this.platform.deviceConfig("wifi.tr64Fallback", false)) {
+        this.fallback = true;
         // fritzapi screen scraping
         this.services.Switch.getCharacteristic(Characteristic.On)
             .on('get', this.getOnFallback.bind(this))
             .on('set', this.setOnFallback.bind(this))
         ;
-    }
-    else {
+
+        this.update(); // execute immediately to get first initial values as fast as possible
+    } else {
         this.platform.log("Using tr64 api for guest Wifi");
 
-        var box = url.parse(this.platform.options.url);
+        const box = url.parse(this.platform.options.url);
 
-        var options = {
-          host: box.host || 'fritz.box',
-          port: this.platform.deviceConfig("wifi.tr64Port", 49443),
-          ssl: this.platform.deviceConfig("wifi.tr64Ssl", true),
-          user: this.platform.config.username,
-          password: this.platform.config.password
+        const options = {
+            host: box.host || 'fritz.box',
+            port: this.platform.deviceConfig("wifi.tr64Port", 49443),
+            ssl: this.platform.deviceConfig("wifi.tr64Ssl", true),
+            user: this.platform.config.username,
+            password: this.platform.config.password
         };
 
-        var tr64 = new TR064(options);
-        var self = this;
+        const tr64 = new TR064(options);
+        const self = this;
 
         tr64.initTR064Device().then(() => {
             // remember service
@@ -74,10 +76,14 @@ function FritzWifiAccessory(platform) {
                 .on('get', self.getOn.bind(self))
                 .on('set', self.setOn.bind(self))
             ;
+
+            this.update(); // execute immediately to get first initial values as fast as possible
         }).catch((err) => {
             self.platform.log.error(err);
         });
     }
+
+    this.services.Switch.fritzState = false;
 
     setInterval(this.update.bind(this), this.platform.interval);
 }
@@ -88,74 +94,69 @@ FritzWifiAccessory.prototype.getServices = function() {
 
 FritzWifiAccessory.prototype.getOn = function(callback) {
     this.platform.log("Getting guest WLAN state");
-    var self = this;
 
-    var service = this.services.Switch;
-    callback(null, service.fritzState);
-
-    this.tr64service.actions.GetInfo().then((res) => {
-        self.platform.log.debug("< %s %s", "tr64.GetInfo", JSON.stringify(res));
-
-        service.fritzState = +res.NewEnable;
-        service.getCharacteristic(Characteristic.On).setValue(service.fritzState, undefined, FritzPlatform.Context);
-    }).catch((err) => {
-        self.platform.log.error(err);
-    });
+    callback(null, this.services.Switch.fritzState);
+    this.queryOn();
 };
 
-FritzWifiAccessory.prototype.setOn = function(on, callback, context) {
-    if (context == FritzPlatform.Context) {
-        callback(null, on);
+FritzWifiAccessory.prototype.setOn = function(on, callback) {
+    this.platform.log("Switching guest WLAN to " + on);
+
+    const payload = {'NewEnable':on ? '1' : '0'};
+    this.tr64service.actions.SetEnable(payload).then(res => {
+        this.platform.log.debug("< %s %s", "tr64.SetEnable", JSON.stringify(res));
+        // TODO: check GetInfo to see if successful
+    }).catch(err => {
+        this.platform.log.error(err);
+    });
+
+    callback();
+};
+
+FritzWifiAccessory.prototype.queryOn = function() {
+    if (!this.tr64service) { // tr64 is still not initialized
         return;
     }
 
-    this.platform.log("Switching guest WLAN to " + on);
-    var self = this;
+    this.tr64service.actions.GetInfo().then(res => {
+        this.platform.log.debug("< %s %s", "tr64.GetInfo", JSON.stringify(res));
 
-    var payload = {'NewEnable':on ? '1' : '0'};
-
-    this.tr64service.actions.SetEnable(payload).then((res) => {
-        self.platform.log.debug("< %s %s", "tr64.SetEnable", JSON.stringify(res));
-
-        // TODO: check GetInfo to see if successful
-        callback(null, on);
+        const service = this.services.Switch;
+        service.fritzState = +res.NewEnable;
+        service.getCharacteristic(Characteristic.On).updateValue(service.fritzState);
     }).catch((err) => {
-        self.platform.log.error(err);
+        this.platform.log.error(err);
     });
 };
 
 FritzWifiAccessory.prototype.getOnFallback = function(callback) {
     this.platform.log("Getting guest WLAN state");
 
-    var service = this.services.Switch;
-    callback(null, service.fritzState);
-
-    this.platform.fritz('getGuestWlan').then(function(res) {
-        service.fritzState = res.activate_guest_access;
-        service.getCharacteristic(Characteristic.On).setValue(res.activate_guest_access, undefined, FritzPlatform.Context);
-    });
+    callback(null, this.services.Switch.fritzState);
+    this.queryOnFallback();
 };
 
-FritzWifiAccessory.prototype.setOnFallback = function(on, callback, context) {
-    if (context == FritzPlatform.Context) {
-        callback(null, on);
-        return;
-    }
-
+FritzWifiAccessory.prototype.setOnFallback = function(on, callback) {
     this.platform.log("Switching guest WLAN to " + on);
 
-    this.platform.fritz('setGuestWlan', on ? true : false).then(function(res) {
-        callback(null, res.activate_guest_access);
+    this.platform.fritz('setGuestWlan', !!on);
+    callback();
+};
+
+FritzWifiAccessory.prototype.queryOnFallback = function() {
+    this.platform.fritz('getGuestWlan').then(res => {
+        const service = this.services.Switch;
+        service.fritzState = res.activate_guest_access;
+        service.getCharacteristic(Characteristic.On).updateValue(res.activate_guest_access);
     });
 };
 
 FritzWifiAccessory.prototype.update = function() {
     this.platform.log("Updating guest WLAN");
-    var self = this;
 
-    var func = this.fallback ? this.getOnFallback.bind(this) : this.getOn.bind(this);
-
-    func(function(foo, state) {
-        self.services.Switch.getCharacteristic(Characteristic.On).setValue(state, undefined, FritzPlatform.Context);
-    }.bind(this));
+    if (this.fallback) {
+        this.queryOnFallback();
+    } else {
+        this.queryOn();
+    }
 };

--- a/lib/accessory.js
+++ b/lib/accessory.js
@@ -9,7 +9,7 @@
 /* jslint node: true, laxcomma: true, esversion: 6 */
 "use strict";
 
-var Service, Characteristic, FritzPlatform;
+let Service, Characteristic, FritzPlatform;
 
 module.exports = function(homebridge) {
     Service = homebridge.hap.Service;
@@ -61,11 +61,18 @@ FritzAccessory.prototype.getCurrentTemperature = function(callback) {
     this.platform.log(`Getting ${this.type} ${this.ain} temperature`);
 
     // characteristic CurrentTemperature is part of multiple services
-    var service = this.services.Thermostat || this.services.TemperatureSensor;
+    const service = this.services.Thermostat || this.services.TemperatureSensor;
     callback(null, service.fritzCurrentTemperature);
+};
 
-    this.platform.fritz('getTemperature', this.ain).then(function(temp) {
-        service.fritzCurrentTemperature = temp;
-        service.getCharacteristic(Characteristic.CurrentTemperature).setValue(temp, undefined, FritzPlatform.Context);
+FritzAccessory.prototype.queryCurrentTemperature = function() {
+    const service = this.services.Thermostat || this.services.TemperatureSensor;
+    if (service === undefined) {
+        return; // called accidentally, ignoring request
+    }
+
+    this.platform.fritz('getTemperature', this.ain).then(temperature => {
+        service.fritzCurrentTemperature = temperature;
+        service.getCharacteristic(Characteristic.CurrentTemperature).updateValue(temperature);
     });
 };

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -51,8 +51,6 @@ function FritzPlatform(log, config) {
     this.promise = null;
 }
 
-FritzPlatform.Context = 'FritzPlatform';
-
 FritzPlatform.PowerUsage = function() {
     Characteristic.call(this, 'Power Usage', 'AE48F447-E065-4B31-8050-8FB06DB9E087');
 


### PR DESCRIPTION
Wie besprochen wird nun ausschließlich `updateValue` benutzt.

Außerdem habe ich, wie ich glaube, ein paar Inkonsistenzen innerhalb des Thermostat accessories behoben. So wie ich das aktuelle Verhalten verstanden habe, setzt das Thermostat bei target=COOL die target temperature auf die night temperature und bei target=HEAT die target temperature auf die comfort temperature(?).

Weiterhin hab ich bisschen code cleanup betrieben und den ein oder anderen kleineren Fehler ausgemerzt, denn ich zufällig entdeckt habe (z.B. würde dass wifi accessory, wenn es im fallback modus ist, nicht die korrekte update Methode aufrufen).

@jngmrks wäre cool, wenn du das mal ausführlich testen und dein feedback da lassen könntest. Hab leider nicht so ein großes Setup und die meisten der Gerät überhaupt nicht.