### PR TITLE
Working version of button.js, tested with Fritz DECT 400

### DIFF
--- a/lib/accessories/button.js
+++ b/lib/accessories/button.js
@@ -66,7 +66,7 @@ FritzButtonAccessory.prototype.getButtonState = function(callback) {
         }
 
         this.lastPressed = lastPressed;
-    });
+    }.bind(this));
 };
 
 FritzButtonAccessory.prototype.update = function() {
@@ -74,6 +74,6 @@ FritzButtonAccessory.prototype.update = function() {
 
     // Switch
     this.getButtonState(function(foo, state) {
-        this.services.Switch.getCharacteristic(Characteristic.SwitchState).setValue(foo, undefined, FritzPlatform.Context);
+        this.services.Switch.getCharacteristic(Characteristic.On).setValue(foo, undefined, FritzPlatform.Context);
     }.bind(this));
 };


### PR DESCRIPTION
Two tiny fixes to @andig's `button.js` support for Fritz DECT 400 switches:

* `SwitchState` [doesn't seem to be a member of `Characteristic`](https://github.com/KhaosT/HAP-NodeJS/blob/master/src/lib/Characteristic.ts#L290). Changed to `On`, as elsewhere in this file.
* Added a `bind(this)` to "getDeviceListFiltered"'s promise callback

Presumably this closes #71 .
Thanks for doing all of the legwork, @andig !