### PR TITLE
Introduce dirty flag to prevent inconsistencies caused my slow queries

### DIFF
--- a/lib/accessories/thermostat.js
+++ b/lib/accessories/thermostat.js
@@ -69,11 +69,13 @@ function FritzThermostatAccessory(platform, ain) {
 
     // init some default values until the first update response arrives
     this.services.Thermostat.fritzCurrentTemperature = 20;
-    this.services.BatteryService.fritzBatteryLevel = 100;
-    this.services.BatteryService.fritzStatusLowBattery = Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL;
     this.services.Thermostat.fritzCurrentHeatingCoolingState = Characteristic.CurrentHeatingCoolingState.OFF;
     this.services.Thermostat.fritzTargetHeatingCoolingState = Characteristic.TargetHeatingCoolingState.OFF;
     this.services.Thermostat.fritzTargetTemperature = 20;
+    this.services.Thermostat.dirty = false; // bool to indicate if a write happened while a read request in still in progress
+
+    this.services.BatteryService.fritzBatteryLevel = 100;
+    this.services.BatteryService.fritzStatusLowBattery = Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL;
 
     this.update(); // execute immediately to get first initial values as fast as possible
     setInterval(this.update.bind(this), this.platform.interval);
@@ -103,9 +105,13 @@ FritzThermostatAccessory.prototype.setTargetHeatingCoolingState = function(state
     let currentState;
     if (state === Characteristic.TargetHeatingCoolingState.OFF) {
         this.platform.fritz("setTempTarget", this.ain, "off");
+        service.dirty = true;
+
         currentState = Characteristic.CurrentHeatingCoolingState.OFF;
     } else if (state === Characteristic.TargetHeatingCoolingState.HEAT) {
         this.platform.fritz("setTempTarget", this.ain, service.fritzTargetTemperature);
+        service.dirty = true;
+
         currentState = this.calculateCurrentHeatingCoolingState();
     }
 
@@ -136,6 +142,7 @@ FritzThermostatAccessory.prototype.setTargetTemperature = function(temperature, 
     service.getCharacteristic(Characteristic.CurrentHeatingCoolingState).updateValue(service.fritzCurrentHeatingCoolingState);
 
     this.platform.fritz('setTempTarget', this.ain, temperature);
+    service.dirty = true;
 
     callback();
 };
@@ -145,8 +152,13 @@ FritzThermostatAccessory.prototype.getTemperatureDisplayUnits = function(callbac
 };
 
 FritzThermostatAccessory.prototype.queryTargetTemperature = function() {
+    const service = this.services.Thermostat;
+    service.dirty = false;
+
     this.platform.fritz('getTempTarget', this.ain).then(temperature => {
-        const service = this.services.Thermostat;
+        if (service.dirty) { // we got a write request while waiting for our update
+            return;
+        }
 
         let targetTemperature = temperature;
         let currentHeatingCoolingState;


### PR DESCRIPTION
Dieser PR ist ein Versuch die in #82 besprochenen kleineren Ungereimtheiten zu fixen: https://github.com/andig/homebridge-fritz/pull/82#issuecomment-573349200.

Beschriebenes Verhalten kann ich bei mir leider nicht reproduzieren, somit basiert der PR nur auf Vermutungen für die mögliche Fehlerursache.
Am besten wäre wenn @jngmrks den PR hier einfach mal testen könnte und kurz berichten könnte, ob das das genannte Problem behebt.

Sollte dies so sein, müsst ich eventuell die anderen accessories die read/write characteristics haben auch noch dementsprechend anpassen.

~ Andi