### PR TITLE
Change case for fritzbox to uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Homebridge platform plugin for FRITZ!Box.
 This plugin exposes:
 
 - WLAN guest access switch
-- Fritz!DECT outlets (200, 210)
-- Fritz!Powerline outlets (510, 540)
-- Fritz!DECT (300, 301) and Comet!DECT thermostats
-- Fritz!DECT (400) buttons
-- Fritz!DECT repeaters as temperature sensor (100)
+- FRITZ!DECT outlets (200, 210)
+- FRITZ!Powerline outlets (510, 540)
+- FRITZ!DECT (300, 301) and Comet!DECT thermostats
+- FRITZ!DECT (400) buttons
+- FRITZ!DECT repeaters as temperature sensor (100)
 - Window sensors including HAN FUN devices e.g. of Deutsche Telekom
 
 ## Installation
@@ -33,8 +33,8 @@ Add platform to `config.json`, for configuration see below.
 {
   "platforms": [
     {
-      "platform": "Fritz!Box",
-      "name": "My FritzBox",
+      "platform": "FRITZ!Box",
+      "name": "My FRITZ!Box",
       "username": "<username>",
       "password": "<password>",
       "url": "http://fritz.box",
@@ -69,7 +69,7 @@ Add platform to `config.json`, for configuration see below.
 
 The following settings are optional:
 
-- `url`: Fritz!Box address
+- `url`: FRITZ!Box address
 - `interval`: polling interval for updating accessories if state was changed outside homebringe
 - `concurrent`: set to `false` to avoid concurrent api requests. May work more stable on older FRITZ!Boxes but has slower performance
 - `devices`: detailed configuration for individual devices. To be uniquely addressable, each device uses its `AIN` as key. The guest wifi device is always called `wifi`. Supported device configuration options are:
@@ -81,12 +81,12 @@ The following settings are optional:
 
 ## Common Issues / Frequently Asked Questions
 
-1. Can't login to the FritzBox
+1. Can't login to the FRITZ!Box
 
-    Some users have reported that logging into the FritzBox internally via `https` fails. This seems to be caused by the FritzApp *occupying* the same port.
+    Some users have reported that logging into the FRITZ!Box internally via `https` fails. This seems to be caused by the FritzApp *occupying* the same port.
     In this case you can connect internally via `http` or use the external IP.
 
-      `Fritz!Box platform login failed` messages can be caused by invalid login data or wrong url.
+      `FRITZ!Box platform login failed` messages can be caused by invalid login data or wrong url.
 
     Log messages if the form of:
 
@@ -96,17 +96,17 @@ The following settings are optional:
 
 2. Unable to update my thermostat
 
-    Current FritzBox firmwares seem to ignore API updates when the thermostat has been key-locked. 
+    Current FRITZ!Box firmwares seem to ignore API updates when the thermostat has been key-locked.
     No workaround available- please contact AVM to change this behaviour or don't use the locking mechanism.
 
 3. Unable to update thermostat battery charge
 
-    Battery charge is not an API function. That means that the user must have access to FritzBox administration, not only to the SmartHome API in order to use this functionality. 
-    Update your Fritz!Box user accordingly. 
+    Battery charge is not an API function. That means that the user must have access to FRITZ!Box administration, not only to the SmartHome API in order to use this functionality.
+    Update your FRITZ!Box user accordingly.
 
 4. Can't toggle guest wifi
 
-    Updating guest wifi state requires both a FritzBox username, password and in some cases an https/ssl connection to the FritzBox. If you use the `password only` option (System > FritzBox Users > Login method) of the FritzBox, make sure you provide any random username value at the `"username"` parameter, otherwise `401 - unauthorized` errors may occur.
+    Updating guest wifi state requires both a FRITZ!Box username, password and in some cases an https/ssl connection to the FRITZ!Box. If you use the `password only` option (System > FRITZ!Box Users > Login method) of the FRITZ!Box, make sure you provide any random username value at the `"username"` parameter, otherwise `401 - unauthorized` errors may occur.
 
 5. Tips for using thermostat with Home App modes and scenes
 

--- a/config.json
+++ b/config.json
@@ -1,8 +1,8 @@
 {
   "platforms": [
     {
-      "platform": "Fritz!Box",
-      "name": "My Fritz!Box",
+      "platform": "FRITZ!Box",
+      "name": "My FRITZ!Box",
       "username": "",
       "password": "",
       "url": "http://fritz.box",

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /**
- * Fritz!Box Platform Plugin for HomeBridge (https://github.com/nfarina/homebridge)
+ * FRITZ!Box Platform Plugin for HomeBridge (https://github.com/nfarina/homebridge)
  *
  * @url https://github.com/andig/homebridge-fritz
  * @author Andreas Götz <cpuidle@gmx.de>
@@ -11,5 +11,5 @@
 
 module.exports = function(homebridge) {
     let FritzPlatform = require('./lib/platform')(homebridge);
-    homebridge.registerPlatform("homebridge-fritz", "Fritz!Box", FritzPlatform);
+    homebridge.registerPlatform("homebridge-fritz", "FRITZ!Box", FritzPlatform);
 };

--- a/lib/accessories/wifi.js
+++ b/lib/accessories/wifi.js
@@ -35,7 +35,7 @@ function FritzWifiAccessory(platform) {
     this.services.AccessoryInformation
         .setCharacteristic(Characteristic.Manufacturer, "AVM");
     this.services.AccessoryInformation
-        .setCharacteristic(Characteristic.Model, "Fritz!Box");
+        .setCharacteristic(Characteristic.Model, "FRITZ!Box");
 
     this.platform.fritz('getOSVersion').then(function(version) {
         this.services.AccessoryInformation

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -43,7 +43,7 @@ function FritzPlatform(log, config) {
 
     // fritz url
     var url = this.config.url || 'http://fritz.box';
-    if (!isWebUri(url)) this.log.warn("Invalid Fritz!Box url - forgot http(s)://?");
+    if (!isWebUri(url)) this.log.warn("Invalid FRITZ!Box url - forgot http(s)://?");
     // trailing slash
     if (url.substr(-1) == "/") url = url.slice(0, -1);
     this.options.url = url;
@@ -81,7 +81,7 @@ FritzPlatform.prototype = {
         var self = this;
 
         fritz.getSessionID(this.config.username, this.config.password, this.options).then(function(sid) {
-            self.log("Fritz!Box platform login successful");
+            self.log("FRITZ!Box platform login successful");
             self.sid = sid;
         })
         .then(function() {
@@ -119,7 +119,7 @@ FritzPlatform.prototype = {
                         }
                     });
 
-                    // add remaining non-api devices that support temperature, e.g. Fritz!DECT 100 repeater
+                    // add remaining non-api devices that support temperature, e.g. FRITZ!DECT 100 repeater
                     var sensors = [];
                     devices.forEach(function(device) {
                         if (device.temperature) {
@@ -195,20 +195,20 @@ FritzPlatform.prototype = {
                 });
             })
             .catch(function(error) {
-                self.log.error("Could not get devices from Fritz!Box. Please check if device supports the smart home API and user has sufficient privileges.");
+                self.log.error("Could not get devices from FRITZ!Box. Please check if device supports the smart home API and user has sufficient privileges.");
                 callback(accessories);
             });
         })
         .catch(function(error) {
             self.log.debug(error);
-            self.log.error("Initializing Fritz!Box platform accessories failed - wrong user credentials?");
+            self.log.error("Initializing FRITZ!Box platform accessories failed - wrong user credentials?");
         });
     },
 
     deviceConfig: function(key, defaultValue) {
         return dotProp.get(this.config.devices, key, defaultValue)
     },
-        
+
     getArrayString: function(array) {
         return array.toString() || "none";
     },
@@ -257,7 +257,7 @@ FritzPlatform.prototype = {
             return fritzFunc.apply(self, funcArgs).catch(function(error) {
                 if (error.response && error.response.statusCode == 403) {
                     return fritz.getSessionID(self.config.username, self.config.password, self.options).then(function(sid) {
-                        self.log("Fritz!Box session renewed");
+                        self.log("FRITZ!Box session renewed");
                         self.log("renewed:"+sid);
                         self.sid = sid;
 
@@ -266,7 +266,7 @@ FritzPlatform.prototype = {
                         return fritzFunc.apply(self, funcArgs);
                     })
                     .catch(function(error) {
-                        self.log.warn("Fritz!Box session renewal failed");
+                        self.log.warn("FRITZ!Box session renewal failed");
                         /* jshint laxbreak:true */
                         throw error === "0000000000000000"
                             ? "Invalid session id"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.9.4",
   "author": "Andreas Goetz <cpuidle@gmx.de>",
   "homepage": "https://github.com/andig/homebridge-fritz#readme",
-  "description": "Homebridge platform plugin for Fritz!Box",
+  "description": "Homebridge platform plugin for FRITZ!Box",
   "keywords": [
     "homebridge-plugin",
     "homebridge",


### PR DESCRIPTION
I suggest for better consistency to always use the uppercase for FRITZ in FRITZ!...

Therefore, I created this pull request.

Best Regards,

Michael