### PR TITLE
Move "Getting.." and "Updating.." messages to debug log

### DIFF
--- a/lib/accessories/alarmsensor.js
+++ b/lib/accessories/alarmsensor.js
@@ -41,7 +41,7 @@ function FritzAlarmSensorAccessory(platform, ain) {
 }
 
 FritzAlarmSensorAccessory.prototype.getSensorState = function(callback) {
-    this.platform.log(`Getting ${this.type} ${this.ain} alarm state`);
+    this.platform.log.debug(`Getting ${this.type} ${this.ain} alarm state`);
 
     callback(null, this.services.ContactSensor.fritzAlarmState);
     this.querySensorState();
@@ -65,6 +65,6 @@ FritzAlarmSensorAccessory.prototype.querySensorState = function() {
 };
 
 FritzAlarmSensorAccessory.prototype.update = function() {
-    this.platform.log(`Updating ${this.type} ${this.ain}`);
+    this.platform.log.debug(`Updating ${this.type} ${this.ain}`);
     this.querySensorState();
 };

--- a/lib/accessories/button.js
+++ b/lib/accessories/button.js
@@ -43,7 +43,7 @@ function FritzButtonAccessory(platform, ain, index, name) {
 }
 
 FritzButtonAccessory.prototype.getButtonState = function(callback) {
-    this.platform.log(`Getting ${this.type} ${this.ain} button state`);
+    this.platform.log.debug(`Getting ${this.type} ${this.ain} button state`);
 
     let service = this.services.Switch;
     callback(null, service.fritzButtonState);
@@ -70,7 +70,7 @@ FritzButtonAccessory.prototype.getButtonState = function(callback) {
 };
 
 FritzButtonAccessory.prototype.update = function() {
-    this.platform.log(`Updating ${this.type} ${this.ain}`);
+    this.platform.log.debug(`Updating ${this.type} ${this.ain}`);
 
     // Switch
     this.getButtonState(function(foo, state) {

--- a/lib/accessories/outlet.js
+++ b/lib/accessories/outlet.js
@@ -76,7 +76,7 @@ function FritzOutletAccessory(platform, ain) {
 }
 
 FritzOutletAccessory.prototype.getOn = function(callback) {
-    this.platform.log(`Getting ${this.type} ${this.ain} state`);
+    this.platform.log.debug(`Getting ${this.type} ${this.ain} state`);
 
     callback(null, this.services.Outlet.fritzState);
 
@@ -101,14 +101,14 @@ FritzOutletAccessory.prototype.queryOn = function() {
 };
 
 FritzOutletAccessory.prototype.getInUse = function(callback) {
-    this.platform.log(`Getting ${this.type} ${this.ain} in use`);
+    this.platform.log.debug(`Getting ${this.type} ${this.ain} in use`);
 
     callback(null, this.services.Outlet.fritzInUse);
     this.queryPowerUsage();
 };
 
 FritzOutletAccessory.prototype.getPowerUsage = function(callback) {
-    this.platform.log(`Getting ${this.type} ${this.ain} power usage`);
+    this.platform.log.debug(`Getting ${this.type} ${this.ain} power usage`);
 
     callback(null, this.services.Outlet.fritzPowerUsage);
     this.queryPowerUsage();
@@ -127,7 +127,7 @@ FritzOutletAccessory.prototype.queryPowerUsage = function() {
 };
 
 FritzOutletAccessory.prototype.getEnergyConsumption = function(callback) {
-    this.platform.log(`Getting ${this.type} ${this.ain} energy consumption`);
+    this.platform.log.debug(`Getting ${this.type} ${this.ain} energy consumption`);
 
     callback(null, this.services.Outlet.fritzEnergyConsumption);
     this.queryEnergyConsumption();
@@ -144,7 +144,7 @@ FritzOutletAccessory.prototype.queryEnergyConsumption = function() {
 };
 
 FritzOutletAccessory.prototype.update = function() {
-    this.platform.log(`Updating ${this.type} ${this.ain}`);
+    this.platform.log.debug(`Updating ${this.type} ${this.ain}`);
 
     // Outlet
     this.queryOn();

--- a/lib/accessories/temperaturesensor.js
+++ b/lib/accessories/temperaturesensor.js
@@ -44,6 +44,6 @@ function FritzTemperatureSensorAccessory(platform, ain) {
 }
 
 FritzTemperatureSensorAccessory.prototype.update = function() {
-    this.platform.log(`Updating ${this.type} ${this.ain}`);
+    this.platform.log.debug(`Updating ${this.type} ${this.ain}`);
     this.queryCurrentTemperature();
 };

--- a/lib/accessories/thermostat.js
+++ b/lib/accessories/thermostat.js
@@ -80,21 +80,21 @@ function FritzThermostatAccessory(platform, ain) {
 }
 
 FritzThermostatAccessory.prototype.getCurrentHeatingCoolingState = function(callback) {
-    this.platform.log(`Getting ${this.type} ${this.ain} current heating state`);
+    this.platform.log.debug(`Getting ${this.type} ${this.ain} current heating state`);
 
     // current state gets queried in getTargetTemperature
     callback(null, this.services.Thermostat.fritzCurrentHeatingCoolingState);
 };
 
 FritzThermostatAccessory.prototype.getTargetHeatingCoolingState = function(callback) {
-    this.platform.log(`Getting ${this.type} ${this.ain} target heating state`);
+    this.platform.log.debug(`Getting ${this.type} ${this.ain} target heating state`);
 
     // target state gets queried in getTargetTemperature
     callback(null, this.services.Thermostat.fritzTargetHeatingCoolingState);
 };
 
 FritzThermostatAccessory.prototype.setTargetHeatingCoolingState = function(state, callback) {
-    this.platform.log(`Setting ${this.type} ${this.ain} heating state`);
+    this.platform.log.debug(`Setting ${this.type} ${this.ain} heating state`);
 
     const service = this.services.Thermostat;
 
@@ -116,7 +116,7 @@ FritzThermostatAccessory.prototype.setTargetHeatingCoolingState = function(state
 };
 
 FritzThermostatAccessory.prototype.getTargetTemperature = function(callback) {
-    this.platform.log(`Getting ${this.type} ${this.ain} target temperature`);
+    this.platform.log.debug(`Getting ${this.type} ${this.ain} target temperature`);
 
     callback(null, this.services.Thermostat.fritzTargetTemperature);
 
@@ -185,7 +185,7 @@ FritzThermostatAccessory.prototype.calculateCurrentHeatingCoolingState = functio
 };
 
 FritzThermostatAccessory.prototype.getBatteryLevel = function(callback) {
-    this.platform.log(`Getting ${this.type} ${this.ain} battery level`);
+    this.platform.log.debug(`Getting ${this.type} ${this.ain} battery level`);
 
     var service = this.services.BatteryService;
     callback(null, service.fritzBatteryLevel);
@@ -196,7 +196,7 @@ FritzThermostatAccessory.prototype.getChargingState = function(callback) {
 };
 
 FritzThermostatAccessory.prototype.getStatusLowBattery = function(callback) {
-    this.platform.log(`Getting ${this.type} ${this.ain} battery status`);
+    this.platform.log.debug(`Getting ${this.type} ${this.ain} battery status`);
 
     var service = this.services.BatteryService;
     callback(null, service.fritzStatusLowBattery);
@@ -218,7 +218,7 @@ FritzThermostatAccessory.prototype.queryBatteryLevel = function() {
 };
 
 FritzThermostatAccessory.prototype.update = function() {
-    this.platform.log(`Updating ${this.type} ${this.ain}`);
+    this.platform.log.debug(`Updating ${this.type} ${this.ain}`);
 
     this.queryCurrentTemperature();
     this.queryTargetTemperature();

--- a/lib/accessories/wifi.js
+++ b/lib/accessories/wifi.js
@@ -93,7 +93,7 @@ FritzWifiAccessory.prototype.getServices = function() {
 };
 
 FritzWifiAccessory.prototype.getOn = function(callback) {
-    this.platform.log("Getting guest WLAN state");
+    this.platform.log.debug("Getting guest WLAN state");
 
     callback(null, this.services.Switch.fritzState);
     this.queryOn();
@@ -130,14 +130,14 @@ FritzWifiAccessory.prototype.queryOn = function() {
 };
 
 FritzWifiAccessory.prototype.getOnFallback = function(callback) {
-    this.platform.log("Getting guest WLAN state");
+    this.platform.log.debug("Getting guest WLAN state");
 
     callback(null, this.services.Switch.fritzState);
     this.queryOnFallback();
 };
 
 FritzWifiAccessory.prototype.setOnFallback = function(on, callback) {
-    this.platform.log("Switching guest WLAN to " + on);
+    this.platform.log.debug("Switching guest WLAN to " + on);
 
     this.platform.fritz('setGuestWlan', !!on);
     callback();
@@ -152,7 +152,7 @@ FritzWifiAccessory.prototype.queryOnFallback = function() {
 };
 
 FritzWifiAccessory.prototype.update = function() {
-    this.platform.log("Updating guest WLAN");
+    this.platform.log.debug("Updating guest WLAN");
 
     if (this.fallback) {
         this.queryOnFallback();

--- a/lib/accessory.js
+++ b/lib/accessory.js
@@ -58,7 +58,7 @@ FritzAccessory.prototype.getServices = function() {
 };
 
 FritzAccessory.prototype.getCurrentTemperature = function(callback) {
-    this.platform.log(`Getting ${this.type} ${this.ain} temperature`);
+    this.platform.log.debug(`Getting ${this.type} ${this.ain} temperature`);
 
     // characteristic CurrentTemperature is part of multiple services
     const service = this.services.Thermostat || this.services.TemperatureSensor;


### PR DESCRIPTION
I use several Fritz thermostats with this plugin, which works great!

However, the Homebridge log is flooded with "Getting thermostat .." and "Updating thermostat .." messages.

Since this information is usually not really important, I changed the log level for these messages to "debug".